### PR TITLE
Serialize objects overriding hashCode

### DIFF
--- a/json/src/main/java/org/teavm/flavour/json/serializer/JsonSerializerContext.java
+++ b/json/src/main/java/org/teavm/flavour/json/serializer/JsonSerializerContext.java
@@ -15,15 +15,15 @@
  */
 package org.teavm.flavour.json.serializer;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
 public class JsonSerializerContext {
     private int lastId;
-    private Map<Object, Integer> ids = new HashMap<>();
-    private Set<Object> touchedObjects = new HashSet<>();
+    private Map<Object, Integer> ids = new IdentityHashMap<>();
+    private Set<Object> touchedObjects = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public boolean hasId(Object object) {
         return ids.containsKey(object);
@@ -39,8 +39,9 @@ public class JsonSerializerContext {
     }
 
     public void touch(Object object) {
-        if (!touchedObjects.add(object)) {
-            throw new IllegalArgumentException("Object has already been serialzied: " + object);
+        if (touchedObjects.contains(object)) {
+            throw new IllegalArgumentException("Object has already been serialized: " + object);
         }
+        touchedObjects.add(object);
     }
 }

--- a/json/src/test/java/org/teavm/flavour/json/test/SerializerTest.java
+++ b/json/src/test/java/org/teavm/flavour/json/test/SerializerTest.java
@@ -44,8 +44,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.teavm.junit.TeaVMTestRunner;
@@ -86,6 +88,27 @@ public class SerializerTest {
         assertTrue("Property `foo' must be an object", fooNode.isObject());
         assertTrue("Property `foo.a` expected", fooNode.has("a"));
         assertTrue("Property `foo.b` expected", fooNode.has("b"));
+    }
+
+    @Ignore
+    public void writesEqualsReference() {
+        C a1 = new C();
+        C a2 = new C();
+        a1.a = a2.a = "ciao";
+
+        C[] array = new C[]{a1, a2};
+
+        JsonNode node = JSONRunner.serialize(array);
+
+        assertTrue("Root node should be JSON array", node.isArray());
+
+        ArrayNode arrayNode = (ArrayNode)node;
+        assertEquals("Length must be 2", 2, arrayNode.size());
+
+        JsonNode firstNode = arrayNode.get(0);
+        assertTrue("Item must be a JSON object", firstNode.isObject());
+        JsonNode secondNode = arrayNode.get(1);
+        assertTrue("Item must be a JSON object", secondNode.isObject());
     }
 
     @Test
@@ -414,6 +437,23 @@ public class SerializerTest {
 
         public void setFoo(Object foo) {
             this.foo = foo;
+        }
+    }
+
+    public static class C {
+        private String a;
+
+        @Override
+        public int hashCode() {
+            return a.hashCode();
+        }
+
+        public String getA() {
+            return a;
+        }
+
+        public void setA(String a) {
+            this.a = a;
         }
     }
 


### PR DESCRIPTION
Equals (by overriding hashCode) objects are detected as same object while they are not.
This made serialization fail while touching the second equal object. In my understanding this is a kind of defense against recursive references. That could be improved as well, not targeted in this pull request.

I used `identityHashCode` as it is implemented by teavm in `org.teavm.classlib.java.lang.TSystem`. Can it be relied on any platform?