### PR TITLE
Fix visibility check for fields and extract visibility settings to static class

### DIFF
--- a/json/src/main/java/org/teavm/flavour/json/emit/ClassInformation.java
+++ b/json/src/main/java/org/teavm/flavour/json/emit/ClassInformation.java
@@ -28,11 +28,11 @@ class ClassInformation {
     InheritanceInformation inheritance = new InheritanceInformation();
     Map<String, PropertyInformation> properties = new HashMap<>();
     Map<String, PropertyInformation> propertiesByOutputName = new HashMap<>();
-    Visibility getterVisibility = Visibility.PUBLIC_ONLY;
-    Visibility isGetterVisibility = Visibility.PUBLIC_ONLY;
-    Visibility setterVisibility = Visibility.ANY;
-    Visibility creatorVisibility = Visibility.NONE;
-    Visibility fieldVisibility = Visibility.NONE;
+    Visibility getterVisibility = ClassInformationDefaults.getterVisibility;
+    Visibility isGetterVisibility = ClassInformationDefaults.isGetterVisibility;
+    Visibility setterVisibility = ClassInformationDefaults.setterVisibility;
+    Visibility creatorVisibility = ClassInformationDefaults.creatorVisibility;
+    Visibility fieldVisibility = ClassInformationDefaults.fieldVisibility;
     IdGeneratorType idGenerator = IdGeneratorType.NONE;
     String idProperty;
     ReflectMethod constructor;

--- a/json/src/main/java/org/teavm/flavour/json/emit/ClassInformationDefaults.java
+++ b/json/src/main/java/org/teavm/flavour/json/emit/ClassInformationDefaults.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.flavour.json.emit;
+
+public class ClassInformationDefaults {
+    public static Visibility getterVisibility = Visibility.PUBLIC_ONLY;
+    public static Visibility isGetterVisibility = Visibility.PUBLIC_ONLY;
+    public static Visibility setterVisibility = Visibility.ANY;
+    public static Visibility creatorVisibility = Visibility.NONE;
+    public static Visibility fieldVisibility = Visibility.NONE;
+}

--- a/json/src/main/java/org/teavm/flavour/json/emit/ClassInformationProvider.java
+++ b/json/src/main/java/org/teavm/flavour/json/emit/ClassInformationProvider.java
@@ -479,7 +479,7 @@ class ClassInformationProvider {
             if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            if (hasExplicitPropertyDeclaration(field) || information.getterVisibility.match(field.getModifiers())) {
+            if (hasExplicitPropertyDeclaration(field) || information.fieldVisibility.match(field.getModifiers())) {
                 addField(information, field.getName(), field);
             }
         }


### PR DESCRIPTION
There is no easy way to change default visibility when serializing. This change adds a simple way to override default visibility for various items by modifying static values using a TeaVM plugin at compile time.

Also fixes the visibility check for fields.

This helped to generate serializers for byte-code only classes at private fields level, where adding annotations was not easily applicable.