### PR TITLE
A new widget to create select options for an enum.

### DIFF
--- a/widgets/src/main/java/org/teavm/flavour/widgets/EnumOptions.java
+++ b/widgets/src/main/java/org/teavm/flavour/widgets/EnumOptions.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2019 ScraM-Team.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.flavour.widgets;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import org.teavm.flavour.templates.BindAttribute;
+import org.teavm.flavour.templates.BindElement;
+import org.teavm.flavour.templates.BindTemplate;
+import org.teavm.flavour.templates.Slot;
+
+@BindElement(name = "enum-options")
+@BindTemplate("templates/flavour/widgets/enum-options.html")
+public class EnumOptions extends AbstractWidget {
+    private Supplier<Enum> enumToShow;
+
+    public EnumOptions(Slot slot) {
+        super(slot);
+    }
+
+    @BindAttribute(name = "enum")
+    public void setEnumToShow(Supplier<Enum> enumToShow) {
+        this.enumToShow = enumToShow;
+    }
+
+    public List<Object> getValues() {
+        return Arrays.asList(enumToShow.get().getDeclaringClass().getEnumConstants());
+    }
+
+    public String displayName(Object enumValue) {
+        return enumValue.toString();
+    }
+}

--- a/widgets/src/main/resources/META-INF/flavour/component-packages/org.teavm.flavour.widgets
+++ b/widgets/src/main/resources/META-INF/flavour/component-packages/org.teavm.flavour.widgets
@@ -1,3 +1,4 @@
 CalendarWidget
 DateField
 Paginator
+EnumOptions

--- a/widgets/src/main/resources/templates/flavour/widgets/enum-options.html
+++ b/widgets/src/main/resources/templates/flavour/widgets/enum-options.html
@@ -1,0 +1,3 @@
+<std:foreach var="item" in="values">
+  <option attr:value="item.toString()"><html:text value="displayName(item)"></option>
+</std:foreach>


### PR DESCRIPTION
This is a new Flavour widget to output HTML option elements for an enum, to simplify creating a select element.

It addresses issue https://github.com/konsoletyper/teavm-flavour/issues/13

Sample usage:
```
    <select html:bidir-value="color">
      <w:enum-options enum="getEnum()"/>
    </select>
```