### PR TITLE
issue 19 JSON Deserialization Should Allow Missing - allow missing fi…

### DIFF
--- a/json/src/main/java/org/teavm/flavour/json/tree/Node.java
+++ b/json/src/main/java/org/teavm/flavour/json/tree/Node.java
@@ -32,7 +32,7 @@ public abstract class Node implements JSObject {
     @JSBody(params = { "node" }, script = "return typeof node == 'string';")
     static native boolean isString(Node node);
 
-    @JSBody(params = { "node" }, script = "return node === null;")
+    @JSBody(params = { "node" }, script = "return node == null;")
     static native boolean isNull(Node node);
 
     @JSBody(params = { "node" }, script = "return typeof node == 'number';")


### PR DESCRIPTION
Per https://github.com/konsoletyper/teavm-flavour/issues/19, allow missing fields during JSON deserialization by consider 'undefined' and 'null' to be the same in the Node.isNull() method.

This is a desirable feature for a project I'm involved with. We have a large java type that is being passed in REST responses with values that are often null. The type is large enough that the byte savings from excluding null fields is the response is worth it. This feature would allow that.