### PR TITLE
JSON: handle required and missing fields

### DIFF
--- a/json/src/main/java/org/teavm/flavour/json/emit/ClassInformationProvider.java
+++ b/json/src/main/java/org/teavm/flavour/json/emit/ClassInformationProvider.java
@@ -355,6 +355,10 @@ class ClassInformationProvider {
             return;
         }
 
+        if (property.required || isRequired(method)) {
+            property.required = true;
+        }
+
         property.outputName = getPropertyName(method, property.outputName);
         PropertyInformation conflictingProperty = information.propertiesByOutputName.get(property.outputName);
         if (conflictingProperty != null) {
@@ -384,6 +388,10 @@ class ClassInformationProvider {
         if (property.ignored || isIgnored(method)) {
             property.ignored = true;
             return;
+        }
+
+        if (property.required || isRequired(method)) {
+            property.required = true;
         }
 
         property.outputName = getPropertyName(method, property.outputName);
@@ -511,6 +519,10 @@ class ClassInformationProvider {
             return property;
         }
 
+        if (property.required || isRequired(annotations)) {
+            property.required = true;
+        }
+
         property.creatorParameterIndex = index;
         property.type = type;
         return property;
@@ -562,6 +574,10 @@ class ClassInformationProvider {
             return;
         }
 
+        if (property.required || isRequired(field)) {
+            property.required = true;
+        }
+
         property.outputName = getPropertyName(field, property.outputName);
         PropertyInformation conflictingProperty = information.propertiesByOutputName.get(property.outputName);
         if (conflictingProperty != null) {
@@ -578,6 +594,14 @@ class ClassInformationProvider {
 
     private boolean isIgnored(ReflectAnnotatedElement annotations) {
         return annotations.getAnnotation(JsonIgnore.class) != null;
+    }
+
+    private boolean isRequired(ReflectAnnotatedElement annotations) {
+        JsonProperty annot = annotations.getAnnotation(JsonProperty.class);
+        if (annot == null) {
+            return false;
+        }
+        return annot.required();
     }
 
     private boolean isGetterName(String name) {

--- a/json/src/main/java/org/teavm/flavour/json/emit/JsonDeserializerEmitter.java
+++ b/json/src/main/java/org/teavm/flavour/json/emit/JsonDeserializerEmitter.java
@@ -500,7 +500,11 @@ public class JsonDeserializerEmitter {
         String propertyName = property.outputName;
         Value<Node> jsonValue = readProperty(property, node, propertyName);
         Value<Object> value = convert(jsonValue, context, type, field);
-        emit(() -> field.set(target.get(), value.get()));
+        emit(() -> {
+            if (!jsonValue.get().isMissing()) {
+                field.set(target.get(), value.get());
+            }
+        });
     }
 
     private Value<Node> readProperty(PropertyInformation property, Value<ObjectNode> node, String propertyName) {
@@ -553,7 +557,7 @@ public class JsonDeserializerEmitter {
             return convertDate(node, annotations);
         }
         Value<JsonDeserializer> deserializer = createDeserializer(type, annotations);
-        return emit(() -> deserializer.get().deserialize(context.get(), node.get()));
+        return emit(() -> node.get().isMissing() ? null : deserializer.get().deserialize(context.get(), node.get()));
     }
 
     private Value<JsonDeserializer> createDeserializer(Type type, ReflectAnnotatedElement annotations) {

--- a/json/src/main/java/org/teavm/flavour/json/emit/PropertyInformation.java
+++ b/json/src/main/java/org/teavm/flavour/json/emit/PropertyInformation.java
@@ -28,6 +28,7 @@ class PropertyInformation implements Cloneable {
     String className;
     ReflectClass<?> type;
     boolean ignored;
+    boolean required;
     Integer creatorParameterIndex;
 
     @Override

--- a/json/src/main/java/org/teavm/flavour/json/tree/Node.java
+++ b/json/src/main/java/org/teavm/flavour/json/tree/Node.java
@@ -32,10 +32,10 @@ public abstract class Node implements JSObject {
     @JSBody(params = { "node" }, script = "return typeof node == 'string';")
     static native boolean isString(Node node);
 
-    @JSBody(params = { "node" }, script = "return node === null || node === undefined;")
+    @JSBody(params = { "node" }, script = "return node === null;")
     static native boolean isNull(Node node);
 
-    @JSBody(params = { "node" }, script = "return node === undefined;")
+    @JSBody(params = { "node" }, script = "return node === void 0;")
     static native boolean isMissing(Node node);
 
     @JSBody(params = { "node" }, script = "return typeof node == 'number';")

--- a/json/src/main/java/org/teavm/flavour/json/tree/Node.java
+++ b/json/src/main/java/org/teavm/flavour/json/tree/Node.java
@@ -32,8 +32,11 @@ public abstract class Node implements JSObject {
     @JSBody(params = { "node" }, script = "return typeof node == 'string';")
     static native boolean isString(Node node);
 
-    @JSBody(params = { "node" }, script = "return node === null;")
+    @JSBody(params = { "node" }, script = "return node === null || node === undefined;")
     static native boolean isNull(Node node);
+
+    @JSBody(params = { "node" }, script = "return node === undefined;")
+    static native boolean isMissing(Node node);
 
     @JSBody(params = { "node" }, script = "return typeof node == 'number';")
     static native boolean isNumber(Node node);
@@ -55,6 +58,10 @@ public abstract class Node implements JSObject {
 
     public final boolean isNull() {
         return isNull(this);
+    }
+
+    public final boolean isMissing() {
+        return isMissing(this);
     }
 
     public final boolean isNumber() {


### PR DESCRIPTION
This PR adds functionality to handle missing and required properties when deserializing JSON.
- As mentioned in #19 it would be nice if the JSON deserializer was able to ignore or skip missing fields.
- Additionally, the framework should handle actually required fields, which are annotated with @JsonProperty(required = true), see #39.

This adds an explicit exception when a required property is missing and otherwise treats all missing fields like  "null" fields.