### PR TITLE
Fix for Issue #46: Some Unicode sequences broken in templates

### DIFF
--- a/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
+++ b/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
@@ -171,7 +171,7 @@ public class Parser {
                 break;
             }
             sb.append(source.subSequence(start, ref.getBegin()));
-            sb.append(Character.toChars(ref.getCodePoint()));
+            sb.appendCodePoint(ref.getCodePoint());
             start = ref.getEnd();
         }
         sb.append(source.subSequence(start, end));

--- a/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
+++ b/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
@@ -171,7 +171,7 @@ public class Parser {
                 break;
             }
             sb.append(source.subSequence(start, ref.getBegin()));
-            sb.append(ref.getChar());
+            sb.append(Character.toChars(ref.getCodePoint()));
             start = ref.getEnd();
         }
         sb.append(source.subSequence(start, end));


### PR DESCRIPTION
Unicode sequences that are supplementary code points are not translated properly in templates.

This changes Parser to support supplementary code points by using a different Jericho API call.

Fixes https://github.com/konsoletyper/teavm-flavour/issues/46
