### PR TITLE
Parsing error reporting

### DIFF
--- a/templates/src/main/java/org/teavm/flavour/templates/emitting/TemplatingProxyGenerator.java
+++ b/templates/src/main/java/org/teavm/flavour/templates/emitting/TemplatingProxyGenerator.java
@@ -90,7 +90,8 @@ public class TemplatingProxyGenerator {
             for (Diagnostic diagnostic : parser.getDiagnostics()) {
                 SourceLocation diagnosticLocation = location != null ? new SourceLocation(location.getMethod(), path,
                         mapper.getLine(diagnostic.getStart()) + 1) : null;
-                diagnostics.error(diagnosticLocation, diagnostic.getMessage());
+                diagnostics.error(diagnosticLocation,
+                        ((location == null) ? path + ": " : "") + diagnostic.getMessage());
             }
         }
 

--- a/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
+++ b/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.CharacterReference;
 import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.Logger;
 import net.htmlparser.jericho.Segment;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
@@ -116,6 +117,48 @@ public class Parser {
 
     public List<TemplateNode> parse(Reader reader, String className) throws IOException {
         source = new Source(reader);
+        final Logger sourceLoggerOrig = source.getLogger();
+        source.setLogger(new Logger() {
+            @Override
+            public void error(String message) {
+                sourceLoggerOrig.error(className + ": " + message);
+            }
+
+            @Override
+            public void warn(String message) {
+                sourceLoggerOrig.warn(message);
+            }
+
+            @Override
+            public void info(String message) {
+                sourceLoggerOrig.info(message);
+            }
+
+            @Override
+            public void debug(String message) {
+                sourceLoggerOrig.debug(message);
+            }
+
+            @Override
+            public boolean isErrorEnabled() {
+                return sourceLoggerOrig.isErrorEnabled();
+            }
+
+            @Override
+            public boolean isWarnEnabled() {
+                return sourceLoggerOrig.isWarnEnabled();
+            }
+
+            @Override
+            public boolean isInfoEnabled() {
+                return sourceLoggerOrig.isInfoEnabled();
+            }
+
+            @Override
+            public boolean isDebugEnabled() {
+                return sourceLoggerOrig.isDebugEnabled();
+            }
+        });
         use(source, "std", "org.teavm.flavour.components.standard");
         use(source, "event", "org.teavm.flavour.components.events");
         use(source, "attr", "org.teavm.flavour.components.attributes");

--- a/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
+++ b/templates/src/main/java/org/teavm/flavour/templates/parsing/Parser.java
@@ -171,7 +171,7 @@ public class Parser {
                 break;
             }
             sb.append(source.subSequence(start, ref.getBegin()));
-            sb.append(ref.getChar());
+            sb.append(Character.toChars(ref.getCodePoint()));
             start = ref.getEnd();
         }
         sb.append(source.subSequence(start, end));


### PR DESCRIPTION
In a large project, it is hard to tell the source of errors in Flavour output, since filenames are missing in some cases.

This change provides more detail in error logs.  Now HTML errors from jericho, and EL parsing errors include a filename.  Example of the new output:

```
[INFO] Running TeaVM
Jun 06, 2020 7:09:31 PM net.htmlparser.jericho.LoggerProviderJava$JavaLogger error
SEVERE: **com.example.Client**: StartTag at (r6,c1,p144) missing required end tag
[INFO] Output file built with errors
[INFO] Debug information successfully written
[INFO] Source maps successfully written
[INFO] Source files successfully written
[ERROR] **templates/client.html**: Variable noSuchField was not found
```

The old output just said this, no filenames or classes:

```
[INFO] Running TeaVM
Jun 06, 2020 6:55:02 PM net.htmlparser.jericho.LoggerProviderJava$JavaLogger error
SEVERE: StartTag at (r6,c1,p144) missing required end tag
```
