### PR TITLE
Path-based routing

### DIFF
--- a/routing/src/main/java/org/teavm/flavour/routing/HashRoutingStrategy.java
+++ b/routing/src/main/java/org/teavm/flavour/routing/HashRoutingStrategy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ScraM-Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teavm.flavour.routing;
+
+import static org.teavm.flavour.routing.Routing.build;
+import org.teavm.jso.browser.Location;
+import org.teavm.jso.browser.Window;
+import org.teavm.jso.dom.html.HTMLElement;
+
+/**
+ * Handles routing via URL hashes.
+ */
+class HashRoutingStrategy implements RoutingStrategy {
+    @Override
+    public void notifyListeners() {
+    }
+
+    @Override
+    public void addListener(RoutingListener listenerNew) {
+    }
+
+    @Override
+    public <T extends Route> T open(Window window, Class<T> routeType) {
+        return build(routeType, hash -> window.getLocation().setHash(hash));
+    }
+
+    @Override
+    public <T extends Route> T replace(Window window, Class<T> routeType) {
+        return build(routeType, hash -> {
+            window.getHistory().replaceState(null, null, "#" + Window.encodeURI(hash));
+        });
+    }
+
+    @Override
+    public String parse(Window window) {
+        Location location = window.getLocation();
+        String hash = location.getHash();
+        if (hash.startsWith("#")) {
+            hash = hash.substring(1);
+        }
+        return hash;
+    }
+
+    @Override
+    public boolean isBlank(Window window) {
+        return window.getLocation().getHash().isEmpty() || window.getLocation().getHash().equals("#");
+    }
+
+    @Override
+    public String makeUri(HTMLElement element, String hash) {
+        return "#" + hash;
+    }
+}

--- a/routing/src/main/java/org/teavm/flavour/routing/PathRoutingStrategy.java
+++ b/routing/src/main/java/org/teavm/flavour/routing/PathRoutingStrategy.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 ScraM-Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teavm.flavour.routing;
+
+import java.util.ArrayList;
+import java.util.List;
+import static org.teavm.flavour.routing.Routing.build;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.browser.Location;
+import org.teavm.jso.browser.Window;
+import org.teavm.jso.dom.html.HTMLDocument;
+import org.teavm.jso.dom.html.HTMLElement;
+
+/**
+ * Handles routing via URL path changes.
+ */
+class PathRoutingStrategy implements RoutingStrategy {
+    private List<RoutingListener> listListeners = new ArrayList<>();
+
+    @JSBody(params = {"document"}, script = "return document.baseURI;")
+    native public static String getBaseUri(HTMLDocument document);
+
+    private String trim(String path) {
+        if (path.startsWith("/")) {
+            return path.substring(1);
+        }
+        else return path;
+    }
+
+    @Override
+    public void notifyListeners() {
+        for (RoutingListener listener : listListeners) {
+            listener.handleLocationChange();
+        }
+    }
+
+    @Override
+    public void addListener(RoutingListener listenerNew) {
+        listListeners.add(listenerNew);
+    }
+
+    @Override
+    public <T extends Route> T open(Window window, Class<T> routeType) {
+        return build(routeType, hash -> {
+            window.getHistory().pushState(null, null, getBaseUri(window.getDocument()) + Window.encodeURI(trim(hash)));
+            notifyListeners();
+        });
+    }
+
+    @Override
+    public <T extends Route> T replace(Window window, Class<T> routeType) {
+        return build(routeType, hash -> {
+            window.getHistory().replaceState(null, null, getBaseUri(window.getDocument()) + Window.encodeURI(trim(hash)));
+            notifyListeners();
+        });
+    }
+
+    @Override
+    public String parse(Window window) {
+        Location location = window.getLocation();
+        String baseUri = getBaseUri(window.getDocument());
+        String fullUrl = location.getFullURL();
+        String path = fullUrl.substring(baseUri.length());
+        if (path.startsWith("#")) {
+            path = path.substring(1);
+        }
+        return "/" + path;
+    }
+
+    @Override
+    public boolean isBlank(Window window) {
+        String path = parse(window);
+        return path.isEmpty();
+    }
+
+    @Override
+    public String makeUri(HTMLElement element, String path) {
+        String pathTrimmed = path.startsWith("/") ? path.substring(1) : path;
+        return getBaseUri(element.getOwnerDocument()) + pathTrimmed;
+    }
+}

--- a/routing/src/main/java/org/teavm/flavour/routing/Route.java
+++ b/routing/src/main/java/org/teavm/flavour/routing/Route.java
@@ -17,7 +17,6 @@ package org.teavm.flavour.routing;
 
 import org.teavm.flavour.routing.emit.PathImplementor;
 import org.teavm.flavour.routing.emit.RoutingImpl;
-import org.teavm.jso.browser.Location;
 import org.teavm.jso.browser.Window;
 
 public interface Route {
@@ -26,12 +25,7 @@ public interface Route {
     }
 
     default boolean parse(Window window) {
-        Location location = window.getLocation();
-        String hash = location.getHash();
-        if (hash.startsWith("#")) {
-            hash = hash.substring(1);
-        }
-        return parse(hash);
+        return parse(Routing.parse(window));
     }
 
     default boolean parse(String path) {

--- a/routing/src/main/java/org/teavm/flavour/routing/Routing.java
+++ b/routing/src/main/java/org/teavm/flavour/routing/Routing.java
@@ -19,8 +19,31 @@ import java.util.function.Consumer;
 import org.teavm.flavour.routing.emit.PathImplementor;
 import org.teavm.flavour.routing.emit.RoutingImpl;
 import org.teavm.jso.browser.Window;
+import org.teavm.jso.dom.html.HTMLElement;
 
 public final class Routing {
+    private static RoutingStrategy routingStrategy = new HashRoutingStrategy();
+
+    public static void usePathStrategy() {
+        routingStrategy = new PathRoutingStrategy();
+    }
+
+    public static void addListener(RoutingListener listenerNew) {
+        routingStrategy.addListener(listenerNew);
+    }
+
+    static String parse(Window window) {
+        return routingStrategy.parse(window);
+    }
+
+    public static boolean isBlank(Window window) {
+        return routingStrategy.isBlank(window);
+    }
+
+    public static String makeUri(HTMLElement element, String path) {
+        return routingStrategy.makeUri(element, path);
+    }
+
     private Routing() {
     }
 
@@ -38,7 +61,7 @@ public final class Routing {
     }
 
     public static <T extends Route> T open(Window window, Class<T> routeType) {
-        return build(routeType, hash -> window.getLocation().setHash(hash));
+        return routingStrategy.open(window, routeType);
     }
 
     public static <T extends Route> T open(Class<T> routeType) {
@@ -46,9 +69,7 @@ public final class Routing {
     }
 
     static <T extends Route> T replace(Window window, Class<T> routeType) {
-        return build(routeType, hash -> {
-            window.getHistory().replaceState(null, null, "#" + Window.encodeURI(hash));
-        });
+        return routingStrategy.replace(window, routeType);
     }
 
     static <T extends Route> T replace(Class<T> routeType) {

--- a/routing/src/main/java/org/teavm/flavour/routing/RoutingListener.java
+++ b/routing/src/main/java/org/teavm/flavour/routing/RoutingListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 ScraM-Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teavm.flavour.routing;
+
+/**
+ * Implement this to be ready to receive notifications that the route has changed.
+ */
+public interface RoutingListener {
+  void handleLocationChange();
+}

--- a/routing/src/main/java/org/teavm/flavour/routing/RoutingStrategy.java
+++ b/routing/src/main/java/org/teavm/flavour/routing/RoutingStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ScraM-Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teavm.flavour.routing;
+
+import org.teavm.jso.browser.Window;
+import org.teavm.jso.dom.html.HTMLElement;
+
+/**
+ * Methods required of a pluggable routing implementation.
+ */
+public interface RoutingStrategy {
+    void notifyListeners();
+
+    void addListener(RoutingListener listenerNew);
+
+    <T extends Route> T open(Window window, Class<T> routeType);
+
+    <T extends Route> T replace(Window window, Class<T> routeType);
+
+    String parse(Window window);
+
+    boolean isBlank(Window window);
+
+    String makeUri(HTMLElement element, String path);
+}

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -34,6 +34,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.teavm.flavour</groupId>
+      <artifactId>teavm-flavour-routing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.teavm</groupId>
       <artifactId>teavm-jso-apis</artifactId>
     </dependency>

--- a/templates/src/main/java/org/teavm/flavour/components/html/LinkComponent.java
+++ b/templates/src/main/java/org/teavm/flavour/components/html/LinkComponent.java
@@ -16,6 +16,7 @@
 package org.teavm.flavour.components.html;
 
 import java.util.function.Consumer;
+import org.teavm.flavour.routing.Routing;
 import org.teavm.flavour.templates.BindAttributeComponent;
 import org.teavm.flavour.templates.BindContent;
 import org.teavm.flavour.templates.ModifierTarget;
@@ -34,7 +35,7 @@ public class LinkComponent implements Renderable {
     }
 
     private Consumer<String> linkConsumer = str -> {
-        value = str;
+        value = Routing.makeUri(element, str);
         setHref(element, value);
     };
 
@@ -52,6 +53,6 @@ public class LinkComponent implements Renderable {
     public void destroy() {
     }
 
-    @JSBody(params = { "elem", "value" }, script = "elem.href = '#' + value;")
+    @JSBody(params = { "elem", "value" }, script = "elem.href = value;")
     private static native void setHref(HTMLElement elem, String value);
 }

--- a/widgets/src/main/java/org/teavm/flavour/widgets/RouteBinder.java
+++ b/widgets/src/main/java/org/teavm/flavour/widgets/RouteBinder.java
@@ -20,12 +20,13 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.teavm.flavour.routing.Route;
 import org.teavm.flavour.routing.Routing;
+import org.teavm.flavour.routing.RoutingListener;
 import org.teavm.flavour.templates.Templates;
 import org.teavm.jso.browser.Window;
 import org.teavm.jso.dom.events.EventListener;
 import org.teavm.jso.dom.events.HashChangeEvent;
 
-public class RouteBinder {
+public class RouteBinder implements RoutingListener {
     Window window;
     private List<Route> routes = new ArrayList<>();
     private Runnable errorHandler;
@@ -38,6 +39,7 @@ public class RouteBinder {
 
     public RouteBinder(Window window) {
         attach(window);
+        Routing.addListener(this);
     }
 
     public Window getWindow() {
@@ -71,7 +73,7 @@ public class RouteBinder {
     }
 
     public void update() {
-        if (window.getLocation().getHash().isEmpty() || window.getLocation().getHash().equals("#")) {
+        if (Routing.isBlank(window)) {
             defaultAction.accept(defaultRoute);
             return;
         }
@@ -94,4 +96,9 @@ public class RouteBinder {
     }
 
     EventListener<HashChangeEvent> listener = evt -> update();
+
+    @Override
+    public void handleLocationChange() {
+        update();
+    }
 }


### PR DESCRIPTION
(This addresses issue #51)

This PR adds Path-based routing to Flavour.  

The existing Hash-based routing has been refactored into a HashRoutingStrategy.  

Routing now redirects to a strategy.  The strategy can be set to path-based via Routing.usePathStrategy().

PathRoutingStrategy implements the path-based routing.

Developers need to do 3 things:
* Call Routing.usePathStrategy()
* Set the base URI in index.html: `<base href="https://frequal.com/tea-sampler/" />`
* Add this to web.xml: '<error-page> <location>/index.html</location> </error-page>'

There is one limitation at present:
* html:link causes a page reload.  Use event:click to avoid this for now.
