### PR TITLE
Support new REST features

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -29,7 +29,7 @@
   <description>Simple application that uses features of TeaVM Flavour</description>
 
   <properties>
-    <jersey.version>2.22.1</jersey.version>
+    <jersey.version>2.26</jersey.version>
     <spring.version>5.1.8.RELEASE</spring.version>
   </properties>
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0.1</version>
+      <version>2.1.1</version>
       <optional>true</optional>
     </dependency>
 

--- a/rest/src/main/java/org/teavm/flavour/rest/impl/model/JAXRSAnnotations.java
+++ b/rest/src/main/java/org/teavm/flavour/rest/impl/model/JAXRSAnnotations.java
@@ -21,6 +21,7 @@ final class JAXRSAnnotations {
     public static final String GET = PREFIX + "GET";
     public static final String PUT = PREFIX + "PUT";
     public static final String POST = PREFIX + "POST";
+    public static final String PATCH = PREFIX + "PATCH";
     public static final String DELETE = PREFIX + "DELETE";
     public static final String HEAD = PREFIX + "HEAD";
     public static final String OPTIONS = PREFIX + "OPTIONS";

--- a/rest/src/main/java/org/teavm/flavour/rest/impl/model/ResourceModelRepository.java
+++ b/rest/src/main/java/org/teavm/flavour/rest/impl/model/ResourceModelRepository.java
@@ -26,6 +26,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.OPTIONS;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -129,6 +130,9 @@ public class ResourceModelRepository {
         } else if (method.getAnnotation(POST.class) != null) {
             dropInheritance(model);
             model.httpMethod = HttpMethod.POST;
+        } else if (method.getAnnotation(PATCH.class) != null) {
+            dropInheritance(model);
+            model.httpMethod = HttpMethod.PATCH;
         } else if (method.getAnnotation(DELETE.class) != null) {
             dropInheritance(model);
             model.httpMethod = HttpMethod.DELETE;
@@ -229,7 +233,8 @@ public class ResourceModelRepository {
             return false;
         } else {
             return Metaprogramming.findClass(String.class).isAssignableFrom(type)
-                    || Metaprogramming.findClass(Number.class).isAssignableFrom(type);
+                    || Metaprogramming.findClass(Number.class).isAssignableFrom(type)
+                    || Metaprogramming.findClass(Enum.class).isAssignableFrom(type);
         }
     }
 

--- a/rest/src/main/java/org/teavm/flavour/rest/processor/HttpMethod.java
+++ b/rest/src/main/java/org/teavm/flavour/rest/processor/HttpMethod.java
@@ -19,6 +19,7 @@ public enum HttpMethod {
     GET,
     PUT,
     POST,
+    PATCH,
     DELETE,
     HEAD,
     OPTIONS

--- a/rest/src/test/java/org/teavm/flavour/rest/test/RestIT.java
+++ b/rest/src/test/java/org/teavm/flavour/rest/test/RestIT.java
@@ -33,10 +33,20 @@ public class RestIT {
     public void passesQueryParams() throws Exception {
         assertEquals(5, service.sum(2, 3));
     }
+    
+    @Test
+    public void passesQueryParamsAsEnum() throws Exception {
+        assertEquals(5, service.sum(2, 3));
+    }
 
     @Test
     public void passesPathParamInsideUrl() throws Exception {
         assertEquals(0, service.sum(10, 7, 3));
+    }
+    
+    @Test
+    public void testPatchMethod() throws Exception {
+        assertEquals(0, service.update(10, 10));
     }
 
     @JSBody(script = "return $test_url;")

--- a/rest/src/test/java/org/teavm/flavour/rest/test/TestService.java
+++ b/rest/src/test/java/org/teavm/flavour/rest/test/TestService.java
@@ -16,6 +16,7 @@
 package org.teavm.flavour.rest.test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
@@ -24,6 +25,11 @@ import org.teavm.flavour.rest.Resource;
 @Resource
 @Path("test")
 public interface TestService {
+    
+    public static enum OP{
+        PLUS, MINUS
+    }
+    
     @GET
     @Path("integers/sum")
     int sum(@QueryParam("a") int a, @QueryParam("b") int b);
@@ -31,4 +37,12 @@ public interface TestService {
     @GET
     @Path("integers/mod-{mod}/sum")
     int sum(@PathParam("mod") int mod, @QueryParam("a") int a, @QueryParam("b") int b);
+    
+    @PATCH
+    @Path("integers/{val}")
+    int update(@PathParam("val") int val, @QueryParam("b") int b);
+    
+    @GET
+    @Path("integers")
+    int op(@QueryParam("op") OP val, @QueryParam("a") int a, @QueryParam("b") int b);
 }

--- a/rest/src/test/java/org/teavm/flavour/rest/test/TestServiceImpl.java
+++ b/rest/src/test/java/org/teavm/flavour/rest/test/TestServiceImpl.java
@@ -27,4 +27,22 @@ public class TestServiceImpl implements TestService {
         return (a + b) % mod;
     }
 
+    @Override
+    public int update(int val, int b) {
+        return val -  b;
+    }
+
+    @Override
+    public int op(OP val, int a, int b) {
+        switch (val) {
+            case PLUS:
+                return a+b;
+            case MINUS:
+                return a-b;
+            default:
+                throw new UnsupportedOperationException("Not yet supported");
+        }
+    }
+    
+    
 }


### PR DESCRIPTION
This PR provides two minor improvments to REST flavour : 
- to support PATCH method introduced with JAX-RS 2.1
- to support enum type for query params