### PR TITLE
EL escape char fix

### DIFF
--- a/expr/src/main/java/org/teavm/flavour/expr/Parser.java
+++ b/expr/src/main/java/org/teavm/flavour/expr/Parser.java
@@ -361,7 +361,7 @@ public class Parser {
             String text = ctx.getText();
             for (int i = 1; i < text.length() - 1; ++i) {
                 char c = text.charAt(i);
-                if (c != '\'') {
+                if (c != '\\') {
                     sb.append(c);
                 } else {
                     c = text.charAt(++i);


### PR DESCRIPTION
When parsing EL strings, the escape character should be \\, but instead the code is looking for '.